### PR TITLE
Add new `matchStyle` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ var Highlight = require('react-highlighter');
 - `caseSensitive`: Determine whether string matching should be case-sensitive. Not applicable to regular expression searches. Defaults to `false`
 - `matchElement`: HTML tag name to wrap around highlighted text. Defaults to `strong`
 - `matchClass`: HTML class to wrap around highlighted text. Defaults to `highlight`
+- `matchStyle`: Custom style for the match element around highlighted text.
 
 
 ## Development

--- a/lib/highlighter.js
+++ b/lib/highlighter.js
@@ -14,14 +14,16 @@ var Highlighter = React.createClass({displayName: "Highlighter",
     ]).isRequired,
     caseSensitive: React.PropTypes.bool,
     matchElement: React.PropTypes.string,
-    matchClass: React.PropTypes.string
+    matchClass: React.PropTypes.string,
+    matchStyle: React.PropTypes.object
   },
 
   getDefaultProps: function() {
     return {
       caseSensitive: false,
       matchElement: 'strong',
-      matchClass: 'highlight'
+      matchClass: 'highlight',
+      matchStyle: {}
     }
   },
 
@@ -171,7 +173,11 @@ var Highlighter = React.createClass({displayName: "Highlighter",
    */
   renderHighlight: function(string) {
     this.count++;
-    return React.DOM[this.props.matchElement]({'key': this.count, 'className': this.props.matchClass}, string);
+    return React.DOM[this.props.matchElement]({
+      key: this.count,
+      className: this.props.matchClass,
+      style: this.props.matchStyle
+    }, string);
   }
 });
 

--- a/test/testHighlighter.js
+++ b/test/testHighlighter.js
@@ -41,6 +41,13 @@ describe('Highlight element', function() {
     expect(matches).to.have.length(1);
   });
 
+  it('should support custom style for matching element', function() {
+    var element = React.createElement(Highlight, {search: 'Seek', matchStyle: { color: 'red' }}, 'Hide and Seek');
+    var node = TestUtils.renderIntoDocument(element);
+    var matches = TestUtils.scryRenderedDOMComponentsWithTag(node, 'strong');
+    expect(matches[0].props.style).to.eql({ color: 'red' });
+  });
+
   it('should support passing props to parent element', function() {
     var element = React.createElement(Highlight, {search: 'world', className: 'myHighlighter'}, 'Hello World');
     var node = TestUtils.renderIntoDocument(element);


### PR DESCRIPTION
A lot of React components use inline styles instead of classes. Some of them probably do this because of idealogical reasons but others do it to simplify things for other components.

For example, a Browserify user recently filed a bug against my devtools monitor because Browserify was not able to import the stylesheet (see bvaughn/redux-devtools-filterable-log-monitor/issues/13). To resolve this I decided to inline styles. Unfortunately I could no longer customize the appearance of highlighted tags.

This PR adds that ability along with a unit test. :)

PS Your package.json should list `react` as a peer dependency because `npm i && npm test` fails without it. I didn't include that change in this PR though because I wanted to keep it focused. :)