### PR TITLE
Escape search string before creating RegExp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,12 @@ language: node_js
 node_js:
   - "0.12"
   - "iojs"
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - gcc-4.8
+    - g++-4.8

--- a/lib/highlighter.js
+++ b/lib/highlighter.js
@@ -1,5 +1,6 @@
 var React = require('react');
 var RegExpPropType = require('./regExpPropType');
+var escapeStringRegexp = require('escape-string-regexp');
 
 
 var Highlighter = React.createClass({displayName: "Highlighter",
@@ -82,7 +83,12 @@ var Highlighter = React.createClass({displayName: "Highlighter",
       flags +='i';
     }
 
-    return new RegExp(this.props.search, flags);
+    var search = this.props.search;
+    if (typeof this.props.search === 'string') {
+      search = escapeStringRegexp(search);
+    }
+
+    return new RegExp(search, flags);
   },
 
   /**

--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
     "jsdom": "^3.1.2",
     "mocha": "^2.2.1",
     "webpack": "^1.7.3"
+  },
+  "dependencies": {
+    "escape-string-regexp": "^1.0.4"
   }
 }

--- a/test/testHighlighter.js
+++ b/test/testHighlighter.js
@@ -58,4 +58,9 @@ describe('Highlight element', function() {
     expect(matches[1].getDOMNode().textContent).to.equal('as');
     expect(matches[2].getDOMNode().textContent).to.equal('ABC');
   });
+
+  it('should support escaping arbitrary string in search', function() {
+    var element = React.createElement(Highlight, {search: 'Test ('}, 'Test (should not throw)');
+    expect(TestUtils.renderIntoDocument.bind(TestUtils, element)).to.not.throw(Error);
+  });
 });


### PR DESCRIPTION
The component should handle escaping of the search property of a `string` type before constructing a new `RegExp` instance. Fixes #17 

It doesn't touch `number` and `boolean` types as they are coerced to `string` automatically.

It uses the [escape-string-regexp](https://github.com/sindresorhus/escape-string-regexp) library because it does the job and it's tested.