### PR TITLE
Add Coveralls.io integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,5 @@
+sudo: false
 language: node_js
 node_js:
-  - "0.12"
-  - "iojs"
+  - node
 script: npm run test-cover
-env:
-  - CXX=g++-4.8
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - gcc-4.8
-    - g++-4.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,12 @@ language: node_js
 node_js:
   - node
 script: npm run test-cover
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - gcc-4.8
+    - g++-4.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - "0.12"
   - "iojs"
-script: npm run coverage && npm run test
+script: npm run test-cover
 env:
   - CXX=g++-4.8
 addons:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![npm version](https://badge.fury.io/js/react-highlighter.svg)](http://badge.fury.io/js/react-highlighter)
 [![Build Status](https://travis-ci.org/helior/react-highlighter.svg?branch=master)](https://travis-ci.org/helior/react-highlighter)
+[![Coverage Status](https://coveralls.io/repos/github/helior/react-highlighter/badge.svg?branch=master)](https://coveralls.io/github/helior/react-highlighter?branch=master)
 
 # react-highlighter
 Highlight select fragments of a string using an HTML element and/or a class.
@@ -36,3 +37,5 @@ Generate a report using Istanbul to make sure your tests are touching everything
 ```
 npm run coverage
 ```
+
+Coveralls.io integration requires that the environment variable `COVERALLS_REPO_TOKEN` is set.

--- a/package.json
+++ b/package.json
@@ -7,15 +7,11 @@
     "react": "^0.14.0"
   },
   "scripts": {
-    "test": "./node_modules/.bin/_mocha",
-    "coverage": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- -R spec",
-    "check-coverage": "./node_modules/.bin/istanbul check-coverage --statement 90 --function 100",
+    "test": "_mocha",
+    "coverage": "istanbul cover _mocha -- -R spec",
+    "check-coverage": "istanbul check-coverage --statement 90 --function 100",
+    "test-cover": "istanbul cover _mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js --verbose",
     "dist": "rm -rf dist/* && ./node_modules/.bin/webpack"
-  },
-  "jest": {
-    "unmockedModulePathPatterns": [
-      "<rootDir>/node_modules/react"
-    ]
   },
   "repository": {
     "type": "git",
@@ -34,10 +30,12 @@
   "homepage": "https://github.com/helior/react-highlighter",
   "devDependencies": {
     "chai": "^2.1.2",
+    "coveralls": "^2.11.2",
     "istanbul": "^0.4.1",
     "jsdom": "^3.1.2",
     "mocha": "^2.3.4",
-    "react-dom": "~0.14.3",
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0",
     "webpack": "^1.7.3"
   },
   "dependencies": {

--- a/test/testHighlighter.js
+++ b/test/testHighlighter.js
@@ -28,6 +28,17 @@ describe('Highlight element', function() {
 
   });
 
+  it('should allow empty search', function() {
+    var element = React.createElement(Highlight, {search: ''}, 'The quick brown fox jumped over the lazy dog.');
+    var node = TestUtils.renderIntoDocument(element);
+    var matches = TestUtils.scryRenderedDOMComponentsWithClass(node, 'highlight');
+
+    expect(ReactDOM.findDOMNode(node).children.length).to.equal(0);
+    expect(matches).to.have.length(0);
+
+  });
+
+
   it('should support custom HTML tag for matching elements', function() {
     var element = React.createElement(Highlight, {search: 'world', matchElement: 'em'}, 'Hello World');
     var node = TestUtils.renderIntoDocument(element);


### PR DESCRIPTION
- adds one more test to make coverage threshold pass
- add React to dev dependency
- Coveralls.io badge, npm script
- Update node version in Travis CI
- Running `npm run test-cover` on Travis script