### PR TITLE
Use React.createElement to allow usage with React 15.0.

### DIFF
--- a/lib/highlighter.js
+++ b/lib/highlighter.js
@@ -29,7 +29,7 @@ var Highlighter = React.createClass({displayName: "Highlighter",
   },
 
   render: function() {
-    return React.DOM.span(React.__spread({}, this.props), this.renderElement(this.props.children));
+    return React.createElement('span', this.props, this.renderElement(this.props.children));
   },
 
   /**


### PR DESCRIPTION
No longer rely upon React.__spread which is breaking on 15.0. Also use React.createElement directly rather than React.DOM.span.