### PR TITLE
blacklist custom props

### DIFF
--- a/lib/highlighter.js
+++ b/lib/highlighter.js
@@ -1,6 +1,7 @@
 var React = require('react');
 var RegExpPropType = require('./regExpPropType');
 var escapeStringRegexp = require('escape-string-regexp');
+var blacklist = require('blacklist');
 
 var Highlighter = React.createClass({displayName: "Highlighter",
   count: 0,
@@ -28,7 +29,9 @@ var Highlighter = React.createClass({displayName: "Highlighter",
   },
 
   render: function() {
-    return React.createElement('span', this.props, this.renderElement(this.props.children));
+    var props = blacklist(this.props, 'search', 'caseSensitive', 'matchElement', 'matchClass', 'matchStyle');
+
+    return React.createElement('span', props, this.renderElement(this.props.children));
   },
 
   /**

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "webpack": "^1.13.1"
   },
   "dependencies": {
+    "blacklist": "^1.1.2",
     "escape-string-regexp": "^1.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,17 +29,17 @@
   },
   "homepage": "https://github.com/helior/react-highlighter",
   "devDependencies": {
-    "chai": "^2.1.2",
-    "coveralls": "^2.11.2",
-    "istanbul": "^0.4.1",
-    "jsdom": "^3.1.2",
-    "mocha": "^2.3.4",
-    "react": "^15.0.0",
-    "react-addons-test-utils": "^15.0.0",
-    "react-dom": "^15.0.0",
-    "webpack": "^1.7.3"
+    "chai": "^3.5.0",
+    "coveralls": "^2.11.9",
+    "istanbul": "^0.4.4",
+    "jsdom": "^9.4.0",
+    "mocha": "^2.5.3",
+    "react": "^15.2.0",
+    "react-addons-test-utils": "^15.2.0",
+    "react-dom": "^15.2.0",
+    "webpack": "^1.13.1"
   },
   "dependencies": {
-    "escape-string-regexp": "^1.0.4"
+    "escape-string-regexp": "^1.0.5"
   }
 }


### PR DESCRIPTION
Since React 15.2.0 we get this warning.

```
Unknown props `matchClass`, `matchElement`, `search`, `caseSensitive`, `matchStyle` on <span> tag. Remove these props from the element.
```

See https://fb.me/react-unknown-prop