### PR TITLE
Fixes deprecation warnings in React 15.5.0

### DIFF
--- a/lib/highlighter.js
+++ b/lib/highlighter.js
@@ -2,21 +2,23 @@ var React = require('react');
 var RegExpPropType = require('./regExpPropType');
 var escapeStringRegexp = require('escape-string-regexp');
 var blacklist = require('blacklist');
+var createReactClass = require('create-react-class');
+var PropTypes = require('prop-types');
 
-var Highlighter = React.createClass({displayName: "Highlighter",
+var Highlighter = createReactClass({displayName: "Highlighter",
   count: 0,
 
   propTypes: {
-    search: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.number,
-      React.PropTypes.bool,
+    search: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+      PropTypes.bool,
       RegExpPropType
     ]).isRequired,
-    caseSensitive: React.PropTypes.bool,
-    matchElement: React.PropTypes.string,
-    matchClass: React.PropTypes.string,
-    matchStyle: React.PropTypes.object
+    caseSensitive: PropTypes.bool,
+    matchElement: PropTypes.string,
+    matchClass: PropTypes.string,
+    matchStyle: PropTypes.object
   },
 
   getDefaultProps: function() {

--- a/package.json
+++ b/package.json
@@ -31,11 +31,12 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "coveralls": "^2.11.9",
+    "create-react-class": "^15.5.2",
     "istanbul": "^0.4.4",
     "jsdom": "^9.4.0",
     "mocha": "^2.5.3",
+    "prop-types": "^15.5.8",
     "react": "^15.2.0",
-    "react-addons-test-utils": "^15.2.0",
     "react-dom": "^15.2.0",
     "webpack": "^1.13.1"
   },

--- a/test/testHighlighter.js
+++ b/test/testHighlighter.js
@@ -1,5 +1,5 @@
 var React = require('react');
-var TestUtils = require('react-addons-test-utils');
+var TestUtils = require('react-dom/test-utils');
 var ReactDOM = require('react-dom');
 var expect = require('chai').expect;
 var Highlight = require('..');


### PR DESCRIPTION
React 15.5.0 introduced deprecation warnings for PropTypes, createClass, and react-addons: https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html

This PR updates dependencies to address those warnings.