### PR TITLE
Fix React deprecation warnings

### DIFF
--- a/lib/highlighter.js
+++ b/lib/highlighter.js
@@ -4,6 +4,7 @@ var escapeStringRegexp = require('escape-string-regexp');
 var blacklist = require('blacklist');
 var createReactClass = require('create-react-class');
 var PropTypes = require('prop-types');
+var DOM = require('react-dom-factories');
 
 var Highlighter = createReactClass({displayName: "Highlighter",
   count: 0,
@@ -19,15 +20,6 @@ var Highlighter = createReactClass({displayName: "Highlighter",
     matchElement: PropTypes.string,
     matchClass: PropTypes.string,
     matchStyle: PropTypes.object
-  },
-
-  getDefaultProps: function() {
-    return {
-      caseSensitive: false,
-      matchElement: 'strong',
-      matchClass: 'highlight',
-      matchStyle: {}
-    }
   },
 
   render: function() {
@@ -174,7 +166,7 @@ var Highlighter = createReactClass({displayName: "Highlighter",
    */
   renderPlain: function(string) {
     this.count++;
-    return React.DOM.span({'key': this.count}, string);
+    return DOM.span({'key': this.count}, string);
   },
 
   /**
@@ -187,12 +179,19 @@ var Highlighter = createReactClass({displayName: "Highlighter",
    */
   renderHighlight: function(string) {
     this.count++;
-    return React.DOM[this.props.matchElement]({
+    return DOM[this.props.matchElement]({
       key: this.count,
       className: this.props.matchClass,
       style: this.props.matchStyle
     }, string);
   }
 });
+
+Highlighter.defaultProps = {
+  caseSensitive: false,
+  matchElement: 'strong',
+  matchClass: 'highlight',
+  matchStyle: {}
+};
 
 module.exports = Highlighter;

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "blacklist": "^1.1.2",
     "create-react-class": "^15.5.2",
     "escape-string-regexp": "^1.0.5",
-    "prop-types": "^15.5.8"
+    "prop-types": "^15.5.8",
+    "react-dom-factories": "^1.0.0"
   }
 }


### PR DESCRIPTION
React 15 warns about the following deprecations:
- Using `getDefaultProps` (#44)
- Accessing factories like `React.DOM.span`