### PR TITLE
Fixing Breaking change in react v16.0+: 

### DIFF
--- a/lib/highlighter.js
+++ b/lib/highlighter.js
@@ -1,11 +1,12 @@
-var React = require('react');
-var RegExpPropType = require('./regExpPropType');
-var escapeStringRegexp = require('escape-string-regexp');
-var blacklist = require('blacklist');
-var createReactClass = require('create-react-class');
-var PropTypes = require('prop-types');
+var React = require("react");
+var RegExpPropType = require("./regExpPropType");
+var escapeStringRegexp = require("escape-string-regexp");
+var blacklist = require("blacklist");
+var createReactClass = require("create-react-class");
+var PropTypes = require("prop-types");
 
-var Highlighter = createReactClass({displayName: "Highlighter",
+var Highlighter = createReactClass({
+  displayName: "Highlighter",
   count: 0,
 
   propTypes: {
@@ -24,16 +25,27 @@ var Highlighter = createReactClass({displayName: "Highlighter",
   getDefaultProps: function() {
     return {
       caseSensitive: false,
-      matchElement: 'strong',
-      matchClass: 'highlight',
+      matchElement: "strong",
+      matchClass: "highlight",
       matchStyle: {}
-    }
+    };
   },
 
   render: function() {
-    var props = blacklist(this.props, 'search', 'caseSensitive', 'matchElement', 'matchClass', 'matchStyle');
+    var props = blacklist(
+      this.props,
+      "search",
+      "caseSensitive",
+      "matchElement",
+      "matchClass",
+      "matchStyle"
+    );
 
-    return React.createElement('span', props, this.renderElement(this.props.children));
+    return React.createElement(
+      "span",
+      props,
+      this.renderElement(this.props.children)
+    );
   },
 
   /**
@@ -61,7 +73,7 @@ var Highlighter = createReactClass({displayName: "Highlighter",
    * @return {Boolean}
    */
   isScalar: function() {
-    return (/string|number|boolean/).test(typeof this.props.children);
+    return /string|number|boolean/.test(typeof this.props.children);
   },
 
   /**
@@ -70,7 +82,7 @@ var Highlighter = createReactClass({displayName: "Highlighter",
    * @return {Boolean}
    */
   hasSearch: function() {
-    return (typeof this.props.search !== 'undefined') && this.props.search;
+    return typeof this.props.search !== "undefined" && this.props.search;
   },
 
   /**
@@ -84,13 +96,13 @@ var Highlighter = createReactClass({displayName: "Highlighter",
       return this.props.search;
     }
 
-    var flags = '';
+    var flags = "";
     if (!this.props.caseSensitive) {
-      flags +='i';
+      flags += "i";
     }
 
     var search = this.props.search;
-    if (typeof this.props.search === 'string') {
+    if (typeof this.props.search === "string") {
       search = escapeStringRegexp(search);
     }
 
@@ -158,7 +170,6 @@ var Highlighter = createReactClass({displayName: "Highlighter",
 
       // And if there's anything left over, recursively run this method again.
       remaining = remaining.slice(boundaries.last);
-
     }
 
     return children;
@@ -174,7 +185,7 @@ var Highlighter = createReactClass({displayName: "Highlighter",
    */
   renderPlain: function(string) {
     this.count++;
-    return React.DOM.span({'key': this.count}, string);
+    return React.createElement("span", { key: this.count, children: string });
   },
 
   /**
@@ -187,12 +198,12 @@ var Highlighter = createReactClass({displayName: "Highlighter",
    */
   renderHighlight: function(string) {
     this.count++;
-    return React.DOM[this.props.matchElement]({
+    return React.createElement(this.props.matchElement, {
       key: this.count,
       className: this.props.matchClass,
-      style: this.props.matchStyle
-    }, string);
+      style: this.props.matchStyle,
+      children: string
+    });
   }
 });
-
 module.exports = Highlighter;


### PR DESCRIPTION
Accessing factories like React.DOM.span has been deprecated and will be removed in v16.0+.
And it will not work by using in React 16.
And this will break component dependent library (https://github.com/ericgio/react-bootstrap-typeahead)
to work properly.

There is also another similar pull-request #45 but it adds additional unnecessary dependency...
An automatic formatting was provided by VS-CODE, it was not intentional, but IMHO it gives better readability.