### PR TITLE
Allow passing React components as matchElement

### DIFF
--- a/lib/highlighter.js
+++ b/lib/highlighter.js
@@ -39,7 +39,7 @@ var Highlighter = createReactClass({
     caseSensitive: PropTypes.bool,
     ignoreDiacritics: PropTypes.bool,
     diacriticsBlacklist: PropTypes.string,
-    matchElement: PropTypes.string,
+    matchElement: PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.func]),
     matchClass: PropTypes.string,
     matchStyle: PropTypes.object
   },

--- a/lib/highlighter.js
+++ b/lib/highlighter.js
@@ -39,7 +39,7 @@ var Highlighter = createReactClass({
     caseSensitive: PropTypes.bool,
     ignoreDiacritics: PropTypes.bool,
     diacriticsBlacklist: PropTypes.string,
-    matchElement: PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.func]),
+    matchElement: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
     matchClass: PropTypes.string,
     matchStyle: PropTypes.object
   },


### PR DESCRIPTION
This fixes a warning related to prop-types in development and closes https://github.com/helior/react-highlighter/issues/55.

Reference: https://github.com/facebook/react/issues/5143#issuecomment-147473269

`typeof SomeClassBasedComponent` is also a function, so we cover both functional and ’normal’ components (as well as strings such as `"div"`). At the same time, passing `<SomeComponent />` (i.e. element instead of just component name) will still trigger a warning.