### PR TITLE
Support React.forwardRef in matchElement

### DIFF
--- a/lib/highlighter.js
+++ b/lib/highlighter.js
@@ -39,7 +39,11 @@ var Highlighter = createReactClass({
     caseSensitive: PropTypes.bool,
     ignoreDiacritics: PropTypes.bool,
     diacriticsBlacklist: PropTypes.string,
-    matchElement: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+    matchElement: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.func,
+      PropTypes.object,
+    ]),
     matchClass: PropTypes.string,
     matchStyle: PropTypes.object
   },


### PR DESCRIPTION
After upgrading to styled-components v4 I noticed dev mode warnings just as before https://github.com/helior/react-highlighter/pull/56. The cause of this was that a styled-component is now create using `React.forwardRef` and this is no longer matched by `PropTypes.oneOfType([PropTypes.string, PropTypes.func])`.


There's currently no way to properly check against `forwardRef` prop-type, see https://github.com/facebook/prop-types/issues/200 for details.

This PR implements a temporary workaround similar to https://github.com/algolia/react-instantsearch/pull/1461. With this change, a warning disappears in my locally opened project.