### PR TITLE
Fix r.slice is not a function

### DIFF
--- a/lib/highlighter.js
+++ b/lib/highlighter.js
@@ -150,7 +150,7 @@ var Highlighter = createReactClass({
   /**
    * Determines which strings of text should be highlighted or not.
    *
-   * @param  {string} subject
+   * @param  {string | number} subject
    *   The body of text that will be searched for highlighted words.
    * @param  {string} search
    *   The search used to search for highlighted words.
@@ -161,6 +161,17 @@ var Highlighter = createReactClass({
   highlightChildren: function(subject, search) {
     var children = [];
     var remaining = subject;
+
+    // If remaining is Number
+    if (typeof remaining === 'number') {
+      // Make string from Number
+      remaining = String(remaining);
+    }
+
+    // if remaining is still not a String throw Error
+    if (typeof remaining !== 'string') {
+      throw new Error('Children must be a String');
+    }
 
     while (remaining) {
       var remainingCleaned = (this.props.ignoreDiacritics

--- a/test/testHighlighter.js
+++ b/test/testHighlighter.js
@@ -30,7 +30,14 @@ describe('Highlight element', function() {
     expect(ReactDOM.findDOMNode(node).children.length).to.equal(3);
     expect(matches).to.have.length(1);
   });
+  it('should accept numbers as children', function() {
+    var element = React.createElement(Highlight, {search: '42'}, 1942);
+    var node = TestUtils.renderIntoDocument(element);
+    var matches = TestUtils.scryRenderedDOMComponentsWithClass(node, 'highlight');
 
+    expect(ReactDOM.findDOMNode(node).children.length).to.equal(2);
+    expect(matches).to.have.length(1);
+  });
   it('should allow empty search', function() {
     var element = React.createElement(Highlight, {search: ''}, 'The quick brown fox jumped over the lazy dog.');
     var node = TestUtils.renderIntoDocument(element);


### PR DESCRIPTION
Hi! When number is passed to the component as children - frontend crashes with an obscure `error r.slice is not a function`. Now if children is Number, it will be converted to String. Otherwise if children is not a Number or String, the Error `Highlighter children must be a String` will be invoked.

Got this error in production, when suddenly server returned a number in element's title.
![image](https://user-images.githubusercontent.com/37555845/51444377-ce9ec900-1d07-11e9-9206-2773c2b5fa8f.png)
